### PR TITLE
Improve CUDA network column handling

### DIFF
--- a/include/NeuroGen/cuda/NetworkCUDA.cuh
+++ b/include/NeuroGen/cuda/NetworkCUDA.cuh
@@ -31,7 +31,9 @@ extern "C" {
 
 // Internal helper functions (not exposed to main.cpp)
 namespace NetworkCUDAInternal {
-    void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen);
+    void createNetworkTopology(std::vector<GPUSynapse>& synapses,
+                               const std::vector<GPUCorticalColumn>& columns,
+                               std::mt19937& gen);
     std::vector<float> applySoftmax(const std::vector<float>& input);
     void updateNetworkStatistics();
     void applyHomeostaticScaling();

--- a/src/cuda/NetworkCUDA.cu
+++ b/src/cuda/NetworkCUDA.cu
@@ -61,6 +61,9 @@ void safeCudaMemset(T* ptr, int value, size_t count) {
 static NetworkConfig g_config;
 static GPUNeuronState* d_neurons = nullptr;
 static GPUSynapse* d_synapses = nullptr;
+static GPUCorticalColumn* d_columns = nullptr;
+static std::vector<GPUCorticalColumn> h_columns;
+static int num_columns = 0;
 static float* d_input_buffer = nullptr;
 static float* d_output_buffer = nullptr;
 static float* d_reward_buffer = nullptr;
@@ -186,7 +189,7 @@ void initializeNetwork() {
     
     // Use trading-optimized configuration by default
     g_config = NetworkPresets::trading_optimized();
-    
+    g_config.finalizeConfig();
     g_config.print();
     
     // Calculate network dimensions
@@ -199,6 +202,18 @@ void initializeNetwork() {
     hidden_end = g_config.input_size + g_config.hidden_size;
     output_start = g_config.input_size + g_config.hidden_size;
     output_end = total_neurons;
+
+    // Build cortical column descriptors for hidden layer
+    h_columns.clear();
+    h_columns.reserve(g_config.numColumns);
+    for (int c = 0; c < g_config.numColumns; ++c) {
+        int ns = hidden_start + c * g_config.neuronsPerColumn;
+        int ne = ns + g_config.neuronsPerColumn;
+        GPUCorticalColumn col{};
+        initGPUCorticalColumn(&col, ns, ne, c);
+        h_columns.push_back(col);
+    }
+    num_columns = static_cast<int>(h_columns.size());
     
     std::cout << "[CUDA] Initializing network with " << total_neurons << " neurons..." << std::endl;
     std::cout << "[CUDA] Input: [" << input_start << ", " << input_end << ")" << std::endl;
@@ -243,7 +258,15 @@ void initializeNetwork() {
     
     // Generate improved network topology
     std::vector<GPUSynapse> host_synapses;
-    NetworkCUDAInternal::createNetworkTopology(host_synapses, gen);
+    NetworkCUDAInternal::createNetworkTopology(host_synapses, h_columns, gen);
+
+    // Patch column synapse ranges
+    size_t syn_cursor = 0;
+    for (auto& col : h_columns) {
+        col.synapse_start = static_cast<int>(syn_cursor);
+        col.synapse_end   = static_cast<int>(syn_cursor + g_config.localFanOut * g_config.neuronsPerColumn);
+        syn_cursor = col.synapse_end;
+    }
     
     total_synapses = host_synapses.size();
     std::cout << "[CUDA] Created " << total_synapses << " synapses" << std::endl;
@@ -252,6 +275,12 @@ void initializeNetwork() {
     if (total_synapses > 0) {
         safeCudaMalloc(&d_synapses, total_synapses);
         safeCudaMemcpy(d_synapses, host_synapses.data(), total_synapses, cudaMemcpyHostToDevice);
+    }
+
+    // Copy cortical columns to GPU
+    if (num_columns > 0) {
+        safeCudaMalloc(&d_columns, num_columns);
+        safeCudaMemcpy(d_columns, h_columns.data(), num_columns, cudaMemcpyHostToDevice);
     }
     
     // Initialize random states
@@ -272,7 +301,9 @@ void initializeNetwork() {
 
 // Enhanced network topology creation
 namespace NetworkCUDAInternal {
-void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen) {
+void createNetworkTopology(std::vector<GPUSynapse>& synapses,
+                           const std::vector<GPUCorticalColumn>& columns,
+                           std::mt19937& gen) {
     std::uniform_real_distribution<float> weight_dist(0.0f, g_config.weight_init_std);
     std::uniform_real_distribution<float> delay_dist(g_config.delay_min, g_config.delay_max);
     std::uniform_real_distribution<float> prob_dist(0.0f, 1.0f);
@@ -288,7 +319,7 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen)
     for (int pre = input_start; pre < input_end; ++pre) {
         for (int post = hidden_start; post < hidden_end; ++post) {
             if (prob_dist(gen) < g_config.input_hidden_prob) {
-                GPUSynapse syn;
+                GPUSynapse syn{};
                 syn.pre_neuron_idx = pre;
                 syn.post_neuron_idx = post;
                 syn.weight = weight_dist(gen) * (prob_dist(gen) < g_config.exc_ratio ? 1.0f : -1.0f);
@@ -300,18 +331,24 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen)
             }
         }
     }
-    
+
     std::cout << "[TOPOLOGY] Created " << connections_created << " input->hidden connections" << std::endl;
     connections_created = 0;
-    
-    // Hidden layer recurrent connections (sparse)
-    for (int pre = hidden_start; pre < hidden_end; ++pre) {
-        for (int post = hidden_start; post < hidden_end; ++post) {
-            if (pre != post && prob_dist(gen) < g_config.hidden_hidden_prob) {
-                GPUSynapse syn;
-                syn.pre_neuron_idx = pre;
-                syn.post_neuron_idx = post;
-                syn.weight = weight_dist(gen) * (prob_dist(gen) < g_config.exc_ratio ? 0.5f : -0.8f);
+
+    // Local recurrent connections within each cortical column
+    for (const auto& col : columns) {
+        for (int n = col.neuron_start; n < col.neuron_end; ++n) {
+            bool is_exc = (n - col.neuron_start) < static_cast<int>(g_config.exc_ratio * g_config.neuronsPerColumn);
+            for (int k = 0; k < g_config.localFanOut; ++k) {
+                int tgt = col.neuron_start + static_cast<int>(prob_dist(gen) * g_config.neuronsPerColumn);
+                if (tgt == n) {
+                    tgt = ((tgt - col.neuron_start + 1) % g_config.neuronsPerColumn) + col.neuron_start;
+                }
+
+                GPUSynapse syn{};
+                syn.pre_neuron_idx = n;
+                syn.post_neuron_idx = tgt;
+                syn.weight = is_exc ? weight_dist(gen) : -weight_dist(gen);
                 syn.delay = delay_dist(gen);
                 syn.last_pre_spike_time = -1000.0f;
                 syn.activity_metric = 0.0f;
@@ -320,8 +357,8 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen)
             }
         }
     }
-    
-    std::cout << "[TOPOLOGY] Created " << connections_created << " hidden->hidden connections" << std::endl;
+
+    std::cout << "[TOPOLOGY] Created " << connections_created << " local column connections" << std::endl;
     connections_created = 0;
     
     // Hidden to Output connections (fully connected)

--- a/src/cuda/NetworkCUDA.cuh
+++ b/src/cuda/NetworkCUDA.cuh
@@ -31,7 +31,9 @@ extern "C" {
 
 // Internal helper functions (not exposed to main.cpp)
 namespace NetworkCUDAInternal {
-    void createNetworkTopology(std::vector<GPUSynapse>& synapses, std::mt19937& gen);
+    void createNetworkTopology(std::vector<GPUSynapse>& synapses,
+                               const std::vector<GPUCorticalColumn>& columns,
+                               std::mt19937& gen);
     std::vector<float> applySoftmax(const std::vector<float>& input);
     void updateNetworkStatistics();
     void applyHomeostaticScaling();


### PR DESCRIPTION
## Summary
- enhance CUDA network configuration to include cortical columns
- expose column-aware topology builder in NetworkCUDA headers
- create column descriptors during initialization and copy to device
- add local column connectivity when generating topology

## Testing
- `g++ -std=c++17 -I./include -I./include/NeuroGen -I./include/NeuroGen/cuda -c main.cpp -o /tmp/main.o`
- `g++ -std=c++17 -I./include -I./include/NeuroGen -I./include/NeuroGen/cuda -c src/TopologyGenerator.cpp -o /tmp/topology.o`


------
https://chatgpt.com/codex/tasks/task_e_6841c26ec9908320aba2af8786be1dce