### PR TITLE
Rename CUDA network statistics struct

### DIFF
--- a/cpu_network_wrapper.cpp
+++ b/cpu_network_wrapper.cpp
@@ -29,8 +29,8 @@ void cleanupNetwork() {
     }
 }
 
-NetworkStats getNetworkStats() {
-    NetworkStats stats{};
+CudaNetworkStats getNetworkStats() {
+    CudaNetworkStats stats{};
     return stats;
 }
 

--- a/cpu_network_wrapper.h
+++ b/cpu_network_wrapper.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include "src/NetworkConfig.h"
 
-struct NetworkStats {
+struct CudaNetworkStats {
     float avg_firing_rate{0};
     float total_spikes{0};
     float avg_weight{0};
@@ -15,6 +15,6 @@ void initializeNetwork();
 std::vector<float> forwardCUDA(const std::vector<float>& input, float reward);
 void updateSynapticWeightsCUDA(float reward);
 void cleanupNetwork();
-NetworkStats getNetworkStats();
+CudaNetworkStats getNetworkStats();
 NetworkConfig getNetworkConfig();
 #endif

--- a/include/NeuroGen/cuda/NetworkCUDA.cuh
+++ b/include/NeuroGen/cuda/NetworkCUDA.cuh
@@ -56,7 +56,7 @@ __global__ void applyHomeostaticScalingKernel(GPUSynapse* synapses, int num_syna
 __global__ void validateNeuronStates(GPUNeuronState* neurons, int num_neurons, bool* is_valid);
 
 // Statistics collected on the GPU network state
-struct NetworkStats {
+struct CudaNetworkStats {
     float avg_firing_rate;
     float total_spikes;
     float avg_weight;
@@ -65,7 +65,7 @@ struct NetworkStats {
 };
 
 // Retrieve the latest statistics from the GPU implementation
-NetworkStats getNetworkStats();
+CudaNetworkStats getNetworkStats();
 
 struct NetworkPerformance {
     float forward_pass_time_ms;

--- a/main.cpp
+++ b/main.cpp
@@ -516,7 +516,7 @@ int main(int argc, char* argv[]) {
             std::cout << "Portfolio Value: $" << std::setprecision(2) << portfolio.getTotalValue() << std::endl;
 
             // Log metrics for this epoch
-            NetworkStats stats = getNetworkStats();
+            CudaNetworkStats stats = getNetworkStats();
             metrics_file << epoch << ',' << portfolio.getTotalValue() << ',' << epoch_return << ','
                          << dopamine_level << ',' << (stats.update_count > 0 ? stats.update_count : 0)
                          << ',' << getNetworkConfig().totalSynapses << '\n';

--- a/src/cuda/NetworkCUDA.cu
+++ b/src/cuda/NetworkCUDA.cu
@@ -85,9 +85,9 @@ static int output_start, output_end;
 // conflicts when the header was included).  This also ensures that the
 // structure used in host code and device code remain consistent.
 
-static NetworkStats g_stats;
+static CudaNetworkStats g_stats;
 
-static void resetNetworkStats(NetworkStats &stats) {
+static void resetNetworkStats(CudaNetworkStats &stats) {
     stats.avg_firing_rate = 0.0f;
     stats.total_spikes    = 0.0f;
     stats.avg_weight      = 0.0f;
@@ -601,7 +601,7 @@ void printNetworkStats() {
     std::cout << "=========================" << std::endl;
 }
 
-NetworkStats getNetworkStats() {
+CudaNetworkStats getNetworkStats() {
     return g_stats;
 }
 

--- a/src/cuda/NetworkCUDA.cuh
+++ b/src/cuda/NetworkCUDA.cuh
@@ -56,7 +56,7 @@ __global__ void applyHomeostaticScalingKernel(GPUSynapse* synapses, int num_syna
 __global__ void validateNeuronStates(GPUNeuronState* neurons, int num_neurons, bool* is_valid);
 
 // Statistics collected on the GPU network state
-struct NetworkStats {
+struct CudaNetworkStats {
     float avg_firing_rate;
     float total_spikes;
     float avg_weight;
@@ -65,7 +65,7 @@ struct NetworkStats {
 };
 
 // Retrieve the latest statistics from the GPU implementation
-NetworkStats getNetworkStats();
+CudaNetworkStats getNetworkStats();
 
 struct NetworkPerformance {
     float forward_pass_time_ms;


### PR DESCRIPTION
## Summary
- rename NetworkStats to CudaNetworkStats in CUDA headers
- update GPU implementation and CPU wrapper
- adjust main program usage

## Testing
- `make test` *(fails: nvcc not found)*
- `make -f Makefile.cpu test-syntax`

------
https://chatgpt.com/codex/tasks/task_e_6842f703fba88320b9ae5294a7df40df