### PR TITLE
Add stub for CudaNetworkAccelerator

### DIFF
--- a/Network.h
+++ b/Network.h
@@ -29,6 +29,7 @@
 
 #if defined(USE_CUDA) && USE_CUDA
 #include "NeuroGen/cuda/NetworkCUDA.cuh"
+#include "NeuroGen/cuda/CudaNetworkAccelerator.h"
 #endif
 
 #include "Neuron.h"

--- a/include/NeuroGen/cuda/CudaNetworkAccelerator.h
+++ b/include/NeuroGen/cuda/CudaNetworkAccelerator.h
@@ -1,0 +1,16 @@
+#ifndef CUDA_NETWORK_ACCELERATOR_H
+#define CUDA_NETWORK_ACCELERATOR_H
+
+/**
+ * @brief Minimal stub for the CUDA network accelerator.
+ *
+ * This placeholder is provided so that CPU builds can compile
+ * even when the full CUDA implementation is unavailable.
+ */
+class CudaNetworkAccelerator {
+public:
+    CudaNetworkAccelerator() = default;
+    ~CudaNetworkAccelerator() = default;
+};
+
+#endif // CUDA_NETWORK_ACCELERATOR_H


### PR DESCRIPTION
## Summary
- create a minimal `CudaNetworkAccelerator` stub header
- include the stub in `Network.h` when CUDA is enabled

## Testing
- `make minimal-test` *(fails: nvcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f70522c483208d7499a53298ff7e