### PR TITLE
Implement eligibility traces and reward-modulated STDP

### DIFF
--- a/include/NeuroGen/GPUNeuralStructures.h
+++ b/include/NeuroGen/GPUNeuralStructures.h
@@ -50,6 +50,7 @@ struct GPUSynapse {
     float last_potentiation;   // Time of last potentiation
     int post_compartment;      // Target compartment on postsynaptic neuron
     int receptor_index;        // Target receptor type
+    float eligibility_trace;   // Eligibility trace for reinforcement learning
 };
 
 /**

--- a/include/NeuroGen/cuda/STDPKernel.cuh
+++ b/include/NeuroGen/cuda/STDPKernel.cuh
@@ -23,7 +23,8 @@ struct GPUNeuronState;
  */
 __global__ void stdpUpdateKernel(GPUSynapse* d_synapses, const GPUNeuronState* d_neurons,
                                 int num_synapses, float A_plus, float A_minus,
-                                float tau_plus, float tau_minus, float current_time,
+                                float tau_plus, float tau_minus, float eligibility_decay,
+                                float learning_rate, float current_time,
                                 float min_weight, float max_weight, float reward_signal);
 
 #ifdef __cplusplus
@@ -46,7 +47,8 @@ extern "C" {
  */
 void launchSTDPUpdateKernel(GPUSynapse* d_synapses, const GPUNeuronState* d_neurons,
                            int num_synapses, float A_plus, float A_minus,
-                           float tau_plus, float tau_minus, float current_time,
+                           float tau_plus, float tau_minus, float eligibility_decay,
+                           float learning_rate, float current_time,
                            float min_weight, float max_weight, float reward_signal);
 
 #ifdef __cplusplus

--- a/src/cuda/GPUNeuralStructures.h
+++ b/src/cuda/GPUNeuralStructures.h
@@ -50,6 +50,7 @@ struct GPUSynapse {
     float last_potentiation;   // Time of last potentiation
     int post_compartment;      // Target compartment on postsynaptic neuron
     int receptor_index;        // Target receptor type
+    float eligibility_trace;   // Eligibility trace for reinforcement learning
 };
 
 /**

--- a/src/cuda/NetworkCUDA.cu
+++ b/src/cuda/NetworkCUDA.cu
@@ -314,6 +314,8 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses,
                 syn.delay = delay_dist(gen);
                 syn.last_pre_spike_time = -1000.0f;
                 syn.activity_metric = 0.0f;
+                syn.last_active = 0.0f;
+                syn.eligibility_trace = 0.0f;
                 synapses.push_back(syn);
                 connections_created++;
             }
@@ -340,6 +342,8 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses,
                 syn.delay = delay_dist(gen);
                 syn.last_pre_spike_time = -1000.0f;
                 syn.activity_metric = 0.0f;
+                syn.last_active = 0.0f;
+                syn.eligibility_trace = 0.0f;
                 synapses.push_back(syn);
                 connections_created++;
             }
@@ -359,6 +363,8 @@ void createNetworkTopology(std::vector<GPUSynapse>& synapses,
             syn.delay = delay_dist(gen);
             syn.last_pre_spike_time = -1000.0f;
             syn.activity_metric = 0.0f;
+            syn.last_active = 0.0f;
+            syn.eligibility_trace = 0.0f;
             synapses.push_back(syn);
             connections_created++;
         }
@@ -544,10 +550,11 @@ void updateSynapticWeightsCUDA(float reward_signal) {
     float A_plus = g_config.A_plus * reward_factor;
     float A_minus = g_config.A_minus * (2.0f - reward_factor); // Inverse for depression
     
-    // Apply STDP with reward modulation
+    // Apply STDP with eligibility traces and reward modulation
     launchSTDPUpdateKernel(d_synapses, d_neurons, total_synapses,
                            A_plus, A_minus, g_config.tau_plus, g_config.tau_minus,
-                           current_time, g_config.min_weight, g_config.max_weight, 
+                           g_config.eligibility_decay, g_config.reward_learning_rate,
+                           current_time, g_config.min_weight, g_config.max_weight,
                            reward_signal);
     CUDA_CHECK_KERNEL();
     

--- a/src/cuda/STDPKernel.cuh
+++ b/src/cuda/STDPKernel.cuh
@@ -23,7 +23,8 @@ struct GPUNeuronState;
  */
 __global__ void stdpUpdateKernel(GPUSynapse* d_synapses, const GPUNeuronState* d_neurons,
                                 int num_synapses, float A_plus, float A_minus,
-                                float tau_plus, float tau_minus, float current_time,
+                                float tau_plus, float tau_minus, float eligibility_decay,
+                                float learning_rate, float current_time,
                                 float min_weight, float max_weight, float reward_signal);
 
 #ifdef __cplusplus
@@ -46,7 +47,8 @@ extern "C" {
  */
 void launchSTDPUpdateKernel(GPUSynapse* d_synapses, const GPUNeuronState* d_neurons,
                            int num_synapses, float A_plus, float A_minus,
-                           float tau_plus, float tau_minus, float current_time,
+                           float tau_plus, float tau_minus, float eligibility_decay,
+                           float learning_rate, float current_time,
                            float min_weight, float max_weight, float reward_signal);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- expand GPU synapse struct with `eligibility_trace`
- extend STDP kernel and wrapper to maintain eligibility traces and update weights using reward modulation
- update network CUDA implementation to use new kernel parameters
- initialize eligibility traces when building network topology

## Testing
- `make minimal-test` *(fails: nvcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68432306646883208d2a5ed3302d882a